### PR TITLE
adding thresholds for alert contacts

### DIFF
--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -96,7 +96,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 	switch m.Type {
 	case "port":
 		m.SubType = intToString(monitorSubType, int(monitor["sub_type"].(float64)))
-		if (m.SubType != "custom") {
+		if m.SubType != "custom" {
 			m.Port = 0
 		} else {
 			m.Port = int(monitor["port"].(float64))
@@ -119,7 +119,9 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 }
 
 type MonitorRequestAlertContact struct {
-	ID int
+	ID         int
+	Threshold  int
+	Recurrence int
 }
 type MonitorCreateRequest struct {
 	FriendlyName string
@@ -164,7 +166,7 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 	}
 	acStrings := make([]string, len(req.AlertContacts))
 	for k, v := range req.AlertContacts {
-		acStrings[k] = fmt.Sprintf("%d", v.ID)
+		acStrings[k] = fmt.Sprintf("%d_%d_%d", v.ID, v.Threshold, v.Recurrence)
 	}
 	data.Add("alert_contacts", strings.Join(acStrings, "-"))
 
@@ -227,7 +229,7 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 	}
 	acStrings := make([]string, len(req.AlertContacts))
 	for k, v := range req.AlertContacts {
-		acStrings[k] = fmt.Sprintf("%d", v.ID)
+		acStrings[k] = fmt.Sprintf("%d_%d_%d", v.ID, v.Threshold, v.Recurrence)
 	}
 	data.Add("alert_contacts", strings.Join(acStrings, "-"))
 

--- a/uptimerobot/resource_uptimerobot_monitor.go
+++ b/uptimerobot/resource_uptimerobot_monitor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func resourceMonitor() *schema.Resource {
@@ -133,7 +133,9 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 	req.AlertContacts = make([]uptimerobotapi.MonitorRequestAlertContact, len(d.Get("alert_contact").([]interface{})))
 	for k, v := range d.Get("alert_contact").([]interface{}) {
 		req.AlertContacts[k] = uptimerobotapi.MonitorRequestAlertContact{
-			ID: v.(map[string]interface{})["id"].(int),
+			ID:         v.(map[string]interface{})["id"].(int),
+			Threshold:  v.(map[string]interface{})["threshold"].(int),
+			Recurrence: v.(map[string]interface{})["recurrence"].(int),
 		}
 	}
 


### PR DESCRIPTION
@louy I have tried working on this but I got very stuck with adding proper tests :( I don't know how which method to use to validate a "hash"

I am pretty sure this actually sets and updates the recurrence and threshold correctly but I can't validate without fixing the tests.

```
    testing.go:518: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }


        (map[string]string) (len=4) {
         (string) (len=15) "alert_contact.#": (string) (len=1) "1",
         (string) (len=18) "alert_contact.0.id": (string) (len=7) "1234",
         (string) (len=26) "alert_contact.0.recurrence": (string) (len=1) "1",
         (string) (len=25) "alert_contact.0.threshold": (string) (len=1) "8"
        }
```

I also think my biggest issue is I somehow need to modify the `GetMonitor` method by adjusting the `type Monitor struct {` to include the `AlertContacts`

Any advice?