### PR TITLE
Generate more portable releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
   - binary: terraform-provider-uptimerobot
+    env:
+      - CGO_ENABLED=0
     goos:
       - windows
       - darwin


### PR DESCRIPTION
Currently trying to use this plugin in an alpine-based docker image will fail with a `not found` error due to alpine not containing the same libc binaries

Setting this flag should mean that terraform-provider-uptimerobot won't rely on the shared libraries being present, which should allow it to work everywhere