### PR TITLE
Allow default alert contact to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ provider "uptimerobot" {
   api_key = "[YOUR MAIN API KEY]"
 }
 
+data "uptimerobot_account" "account" {}
+
+data "uptimerobot_alert_contact" "default_alert_contact" {
+  friendly_name = "${data.uptimerobot_account.account.email}"
+}
+
 resource "uptimerobot_alert_contact" "slack" {
   friendly_name = "Slack Alert"
   type          = "slack"
@@ -26,6 +32,10 @@ resource "uptimerobot_monitor" "main" {
     id = "${uptimerobot_alert_contact.slack.id}"
     # threshold  = 0  # pro only
     # recurrence = 0  # pro only
+  }
+
+  alert_contact {
+    id = "${data.uptimerobot_alert_contact.default_alert_contact.id}"
   }
 }
 

--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 )
 
 // maximum pagination depth to allow (10*50=500 entries)
@@ -151,7 +150,7 @@ func (client UptimeRobotApiClient) CreateAlertContact(req AlertContactCreateRequ
 	// The difference made by it being a string is that a zero prefix to the ID // number is preserved. A zero prefixed alert contact ID is thus far only
 	// been observed on the default alert contact (created at account creation).
 	// https://github.com/louy/terraform-provider-uptimerobot/pull/21
-	return client.GetAlertContact(strconv.Itoa(alertcontact["id"].(int)))
+	return client.GetAlertContact(fmt.Sprintf("%.0f", alertcontact["id"].(float64)))
 }
 
 func (client UptimeRobotApiClient) DeleteAlertContact(id string) (err error) {

--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 // maximum pagination depth to allow (10*50=500 entries)
@@ -144,7 +145,13 @@ func (client UptimeRobotApiClient) CreateAlertContact(req AlertContactCreateRequ
 		return
 	}
 
-	return client.GetAlertContact(alertcontact["id"].(string))
+	// The alert contact ID is a string value according to API docs but is
+	// returned as a integer value by the newAlertContact API JSON. In other
+	// places the API does correctly handle it as a string value.
+	// The difference made by it being a string is that a zero prefix to the ID // number is preserved. A zero prefixed alert contact ID is thus far only
+	// been observed on the default alert contact (created at account creation).
+	// https://github.com/louy/terraform-provider-uptimerobot/pull/21
+	return client.GetAlertContact(strconv.Itoa(alertcontact["id"].(int)))
 }
 
 func (client UptimeRobotApiClient) DeleteAlertContact(id string) (err error) {

--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -178,7 +178,7 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 	}
 	acStrings := make([]string, len(req.AlertContacts))
 	for k, v := range req.AlertContacts {
-		acStrings[k] = fmt.Sprintf("%d_%d_%d", v.ID, v.Threshold, v.Recurrence)
+		acStrings[k] = fmt.Sprintf("%s_%d_%d", v.ID, v.Threshold, v.Recurrence)
 	}
 	data.Add("alert_contacts", strings.Join(acStrings, "-"))
 
@@ -251,7 +251,7 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 	}
 	acStrings := make([]string, len(req.AlertContacts))
 	for k, v := range req.AlertContacts {
-		acStrings[k] = fmt.Sprintf("%d_%d_%d", v.ID, v.Threshold, v.Recurrence)
+		acStrings[k] = fmt.Sprintf("%s_%d_%d", v.ID, v.Threshold, v.Recurrence)
 	}
 	data.Add("alert_contacts", strings.Join(acStrings, "-"))
 

--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -129,7 +129,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 }
 
 type MonitorRequestAlertContact struct {
-	ID         int
+	ID         string
 	Threshold  int
 	Recurrence int
 }

--- a/uptimerobot/data_source_uptimerobot_alert_contact.go
+++ b/uptimerobot/data_source_uptimerobot_alert_contact.go
@@ -1,0 +1,51 @@
+package uptimerobot
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+)
+
+func dataSourceAlertContact() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlertContactRead,
+		Schema: map[string]*schema.Schema{
+			"friendly_name": {Optional: true, Type: schema.TypeString},
+			"id":            {Computed: true, Type: schema.TypeString},
+			"type":          {Computed: true, Type: schema.TypeString},
+			"status":        {Computed: true, Type: schema.TypeString},
+			"value":         {Optional: true, Type: schema.TypeString},
+		},
+	}
+}
+
+func dataSourceAlertContactRead(d *schema.ResourceData, m interface{}) error {
+	alertContacts, err := m.(uptimerobotapi.UptimeRobotApiClient).GetAlertContacts()
+	if err != nil {
+		return err
+	}
+
+	friendlyName := d.Get("friendly_name").(string)
+
+	var alertContact uptimerobotapi.AlertContact
+
+	for _, a := range alertContacts {
+		if friendlyName != "" && a.FriendlyName == friendlyName {
+			alertContact = a
+			break
+		}
+	}
+	if alertContact == (uptimerobotapi.AlertContact{}) {
+		return fmt.Errorf("Failed to find alert contact by name %s", friendlyName)
+	}
+
+	d.SetId(alertContact.ID)
+
+	d.Set("friendly_name", alertContact.FriendlyName)
+	d.Set("type", alertContact.Type)
+	d.Set("status", alertContact.Status)
+	d.Set("value", alertContact.Value)
+
+	return nil
+}

--- a/uptimerobot/provider.go
+++ b/uptimerobot/provider.go
@@ -26,7 +26,8 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"uptimerobot_account": dataSourceAccount(),
+			"uptimerobot_account":       dataSourceAccount(),
+			"uptimerobot_alert_contact": dataSourceAlertContact(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"uptimerobot_alert_contact": resourceAlertContact(),

--- a/uptimerobot/resource_uptimerobot_alert_contact.go
+++ b/uptimerobot/resource_uptimerobot_alert_contact.go
@@ -1,12 +1,9 @@
 package uptimerobot
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func resourceAlertContact() *schema.Resource {
@@ -54,17 +51,14 @@ func resourceAlertContactCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%d", ac.ID))
+	d.SetId(ac.ID)
 	updateAlertContactResource(d, ac)
 
 	return nil
 }
 
 func resourceAlertContactRead(d *schema.ResourceData, m interface{}) error {
-	id, err := strconv.Atoi(d.Id())
-	if err != nil {
-		return err
-	}
+	id := d.Id()
 
 	ac, err := m.(uptimerobotapi.UptimeRobotApiClient).GetAlertContact(id)
 	if err != nil {
@@ -77,12 +71,9 @@ func resourceAlertContactRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAlertContactUpdate(d *schema.ResourceData, m interface{}) error {
-	id, err := strconv.Atoi(d.Id())
-	if err != nil {
-		return err
-	}
+	id := d.Id()
 
-	err = m.(uptimerobotapi.UptimeRobotApiClient).UpdateAlertContact(
+	err := m.(uptimerobotapi.UptimeRobotApiClient).UpdateAlertContact(
 		uptimerobotapi.AlertContactUpdateRequest{
 			ID:           id,
 			FriendlyName: d.Get("friendly_name").(string),
@@ -96,12 +87,9 @@ func resourceAlertContactUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAlertContactDelete(d *schema.ResourceData, m interface{}) error {
-	id, err := strconv.Atoi(d.Id())
-	if err != nil {
-		return err
-	}
+	id := d.Id()
 
-	err = m.(uptimerobotapi.UptimeRobotApiClient).DeleteAlertContact(id)
+	err := m.(uptimerobotapi.UptimeRobotApiClient).DeleteAlertContact(id)
 	if err != nil {
 		return err
 	}

--- a/uptimerobot/resource_uptimerobot_alert_contact_test.go
+++ b/uptimerobot/resource_uptimerobot_alert_contact_test.go
@@ -2,13 +2,12 @@ package uptimerobot
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func TestUptimeRobotDataResourceAlertContact_email(t *testing.T) {
@@ -127,12 +126,9 @@ func testAccCheckAlertContactDestroy(s *terraform.State) error {
 			continue
 		}
 
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
+		id := rs.Primary.ID
 
-		_, err = client.GetAlertContact(id)
+		_, err := client.GetAlertContact(id)
 
 		if err == nil {
 			return fmt.Errorf("Alert contact still exists")

--- a/uptimerobot/resource_uptimerobot_monitor.go
+++ b/uptimerobot/resource_uptimerobot_monitor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func resourceMonitor() *schema.Resource {
@@ -81,7 +81,7 @@ func resourceMonitor() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Required: true,
 						},
 						"threshold": {
@@ -211,7 +211,7 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 	req.AlertContacts = make([]uptimerobotapi.MonitorRequestAlertContact, len(d.Get("alert_contact").([]interface{})))
 	for k, v := range d.Get("alert_contact").([]interface{}) {
 		req.AlertContacts[k] = uptimerobotapi.MonitorRequestAlertContact{
-			ID: v.(map[string]interface{})["id"].(int),
+			ID: v.(map[string]interface{})["id"].(string),
 		}
 	}
 

--- a/uptimerobot/resource_uptimerobot_monitor.go
+++ b/uptimerobot/resource_uptimerobot_monitor.go
@@ -136,7 +136,7 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 	req.AlertContacts = make([]uptimerobotapi.MonitorRequestAlertContact, len(d.Get("alert_contact").([]interface{})))
 	for k, v := range d.Get("alert_contact").([]interface{}) {
 		req.AlertContacts[k] = uptimerobotapi.MonitorRequestAlertContact{
-			ID:         v.(map[string]interface{})["id"].(int),
+			ID:         v.(map[string]interface{})["id"].(string),
 			Threshold:  v.(map[string]interface{})["threshold"].(int),
 			Recurrence: v.(map[string]interface{})["recurrence"].(int),
 		}


### PR DESCRIPTION
- Convert alert contact ID to string (it can be 0 padded number)
- Add alert contact datasource
- Extend example configuration with default alert contact

TODO:

- [x] Pagination
- [x] Migration code for int to string conversion alert contact id
- [x] Tests
