### PR TITLE
Set proper value of contact type for pushover

### DIFF
--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -18,7 +18,7 @@ var alertContactType = map[string]int{
 	"webhook":    5,
 	"pushbullet": 6,
 	"zapier":     7,
-	"pushover":   8,
+	"pushover":   9,
 	"hipchat":    10,
 	"slack":      11,
 }


### PR DESCRIPTION
According to documentation https://uptimerobot.com/api, pushover alert should be mapped to "9" value.