### PR TITLE
Fix setting threshold and recurrence on update

### DIFF
--- a/uptimerobot/resource_uptimerobot_monitor.go
+++ b/uptimerobot/resource_uptimerobot_monitor.go
@@ -211,7 +211,9 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 	req.AlertContacts = make([]uptimerobotapi.MonitorRequestAlertContact, len(d.Get("alert_contact").([]interface{})))
 	for k, v := range d.Get("alert_contact").([]interface{}) {
 		req.AlertContacts[k] = uptimerobotapi.MonitorRequestAlertContact{
-			ID: v.(map[string]interface{})["id"].(string),
+			ID:         v.(map[string]interface{})["id"].(string),
+			Threshold:  v.(map[string]interface{})["threshold"].(int),
+			Recurrence: v.(map[string]interface{})["recurrence"].(int),
 		}
 	}
 


### PR DESCRIPTION
This fixes setting the `threshold` and `recurrence` properties when a monitor changes.

Some things to note.

1. I added this feature and totally forgot to implement this PR #18
2. I couldn't find a way for us to check the alert contact's `threshold` and `recurrence` as part of the plan loop this will only work when you update the code/state. There is no way for this provider currently to detect a difference between the uptime robot config in uptime robot and this state.