### PR TITLE
[WIP] Adds http_auth_type to Monitor Resource

### DIFF
--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -41,6 +41,12 @@ var monitorKeywordType = map[string]int{
 }
 var MonitorKeywordType = mapKeys(monitorKeywordType)
 
+var monitorHTTPAuthType = map[string]int{
+	"basic":  1,
+	"digest": 2,
+}
+var MonitorHTTPAuthType = mapKeys(monitorHTTPAuthType)
+
 type Monitor struct {
 	ID           int    `json:"id"`
 	FriendlyName string `json:"friendly_name"`
@@ -57,6 +63,7 @@ type Monitor struct {
 
 	HTTPUsername string `json:"http_username"`
 	HTTPPassword string `json:"http_password"`
+	HTTPAuthType string `json:"http_auth_type"`
 
 	CustomHTTPHeaders map[string]string
 }
@@ -112,10 +119,12 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 
 		m.HTTPUsername = monitor["http_username"].(string)
 		m.HTTPPassword = monitor["http_password"].(string)
+		m.HTTPAuthType = intToString(monitorHTTPAuthType, int(monitor["http_auth_type"].(float64)))
 		break
 	case "http":
 		m.HTTPUsername = monitor["http_username"].(string)
 		m.HTTPPassword = monitor["http_password"].(string)
+		m.HTTPAuthType = intToString(monitorHTTPAuthType, int(monitor["http_auth_type"].(float64)))
 		break
 	}
 
@@ -147,6 +156,7 @@ type MonitorCreateRequest struct {
 
 	HTTPUsername string
 	HTTPPassword string
+	HTTPAuthType string
 
 	AlertContacts []MonitorRequestAlertContact
 
@@ -170,10 +180,12 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		break
 	case "http":
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		break
 	}
 	acStrings := make([]string, len(req.AlertContacts))
@@ -219,6 +231,7 @@ type MonitorUpdateRequest struct {
 
 	HTTPUsername string
 	HTTPPassword string
+	HTTPAuthType string
 
 	AlertContacts []MonitorRequestAlertContact
 
@@ -243,10 +256,12 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		break
 	case "http":
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		break
 	}
 	acStrings := make([]string, len(req.AlertContacts))

--- a/uptimerobot/resource_uptimerobot_monitor.go
+++ b/uptimerobot/resource_uptimerobot_monitor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func resourceMonitor() *schema.Resource {
@@ -70,6 +70,11 @@ func resourceMonitor() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
+			"http_auth_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(uptimerobotapi.MonitorHTTPAuthType, false),
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -123,10 +128,12 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
+		req.HTTPAuthType = d.Get("http_auth_type").(string)
 		break
 	case "http":
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
+		req.HTTPAuthType = d.Get("http_auth_type").(string)
 		break
 	}
 
@@ -198,10 +205,12 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
+		req.HTTPAuthType = d.Get("http_auth_type").(string)
 		break
 	case "http":
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
+		req.HTTPAuthType = d.Get("http_auth_type").(string)
 		break
 	}
 
@@ -261,6 +270,7 @@ func updateMonitorResource(d *schema.ResourceData, m uptimerobotapi.Monitor) {
 
 	d.Set("http_username", m.HTTPUsername)
 	d.Set("http_password", m.HTTPPassword)
+	d.Set("http_auth_type", m.HTTPAuthType)
 
 	d.Set("custom_http_headers", m.CustomHTTPHeaders)
 }

--- a/uptimerobot/resource_uptimerobot_monitor_test.go
+++ b/uptimerobot/resource_uptimerobot_monitor_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
+	uptimerobotapi "github.com/louy/terraform-provider-uptimerobot/uptimerobot/api"
 )
 
 func TestUptimeRobotDataResourceMonitor_http_monitor(t *testing.T) {
@@ -388,6 +388,8 @@ func TestUptimeRobotDataResourceMonitor_http_auth_monitor(t *testing.T) {
 	var Type = "http"
 	var Username = "tester"
 	var Password = "secret"
+	var AuthType = "basic"
+	var AuthType2 = "digest"
 	var URL = fmt.Sprintf("https://httpbin.org/basic-auth/%s/%s", Username, Password)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -397,19 +399,54 @@ func TestUptimeRobotDataResourceMonitor_http_auth_monitor(t *testing.T) {
 			resource.TestStep{
 				Config: fmt.Sprintf(`
 				resource "uptimerobot_monitor" "test" {
-					friendly_name = "%s"
-					type          = "%s"
-					url           = "%s"
-					http_username = "%s"
-					http_password = "%s"
+					friendly_name  = "%s"
+					type           = "%s"
+					url            = "%s"
+					http_username  = "%s"
+					http_password  = "%s"
+					http_auth_type = "%s"
 				}
-				`, FriendlyName, Type, URL, Username, Password),
+				`, FriendlyName, Type, URL, Username, Password, AuthType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_username", Username),
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_password", Password),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_auth_type", AuthType),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "uptimerobot_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name  = "%s"
+					type           = "%s"
+					url            = "%s"
+					http_username  = "%s"
+					http_password  = "%s"
+					http_auth_type = "%s"
+				}
+				`, FriendlyName, Type, URL, Username, Password, AuthType2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_username", Username),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_password", Password),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "http_auth_type", AuthType2),
 				),
 			},
 			resource.TestStep{

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -42,8 +42,11 @@ resource "uptimerobot_monitor" "my_website" {
       - `imap`
       - `custom`
     - `port` - the port monitored (only if subtype is `custom`)
-* `http_username` - used for password-protected web pages (HTTP Basic Auth). Available for HTTP and keyword monitoring.
-* `http_password` - used for password-protected web pages (HTTP Basic Auth). Available for HTTP and keyword monitoring.
+* `http_username` - used for password-protected web pages (HTTP basic or digest). Available for HTTP and keyword monitoring.
+* `http_password` - used for password-protected web pages (HTTP basic or digest). Available for HTTP and keyword monitoring.
+* `http_auth_type` - Used for password-protected web pages (HTTP basic or digest). Available for HTTP and keyword monitoring. Can be one of the following:
+  - `basic`
+  - `digest`
 * `interval` - the interval for the monitoring check (300 seconds by default).
 
 ## Attributes Reference


### PR DESCRIPTION
Adds support for specifying the http_auth_type parameter to the monitor
resource.

Fixes louy/terraform-provider-uptimerobot#71

Signed-off-by: Jason Rogena <jason@rogena.me>