### PR TITLE
Fix alert_contact import in monitor resource

### DIFF
--- a/uptimerobot/resource_uptimerobot_monitor_test.go
+++ b/uptimerobot/resource_uptimerobot_monitor_test.go
@@ -249,10 +249,9 @@ func TestUptimeRobotDataResourceMonitor_custom_alert_contact_threshold_and_recur
 				),
 			},
 			resource.TestStep{
-				ResourceName: "uptimerobot_monitor.test",
-				ImportState:  true,
-				// uptimerobot doesn't support pulling alert_contact
-				// ImportStateVerify: true,
+				ResourceName:      "uptimerobot_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -417,8 +416,8 @@ func TestUptimeRobotDataResourceMonitor_http_auth_monitor(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      "uptimerobot_monitor.test",
-				ImportState:       true,
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
 				// NB: Disabled due to http_auth_type issue
 				// ImportStateVerify: true,
 			},
@@ -443,8 +442,8 @@ func TestUptimeRobotDataResourceMonitor_http_auth_monitor(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      "uptimerobot_monitor.test",
-				ImportState:       true,
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
 				// NB: Disabled due to http_auth_type issue
 				// ImportStateVerify: true,
 			},


### PR DESCRIPTION
Seems like UR added an API feature to allow reading alert_contact, which I don't think was present before