### PR TITLE
Fix deprecated interpolation-only expresssions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ provider "uptimerobot" {
 data "uptimerobot_account" "account" {}
 
 data "uptimerobot_alert_contact" "default_alert_contact" {
-  friendly_name = "${data.uptimerobot_account.account.email}"
+  friendly_name = data.uptimerobot_account.account.email
 }
 
 resource "uptimerobot_alert_contact" "slack" {
@@ -41,13 +41,13 @@ resource "uptimerobot_monitor" "main" {
   interval      = 300
 
   alert_contact {
-    id = "${uptimerobot_alert_contact.slack.id}"
+    id = uptimerobot_alert_contact.slack.id
     # threshold  = 0  # pro only
     # recurrence = 0  # pro only
   }
 
   alert_contact {
-    id = "${data.uptimerobot_alert_contact.default_alert_contact.id}"
+    id = data.uptimerobot_alert_contact.default_alert_contact.id
   }
 }
 
@@ -64,13 +64,13 @@ resource "uptimerobot_status_page" "main" {
   custom_domain  = "status.example.com"
   password       = "WeAreAwsome"
   sort           = "down-up-paused"
-  monitors       = ["${uptimerobot_monitor.main.id}"]
+  monitors       = [uptimerobot_monitor.main.id]
 }
 
 resource "aws_route53_record" {
   zone_id = "[MY ZONE ID]"
   type    = "CNAME"
-  records = ["${uptimerobot_status_page.main.dns_address}"]
+  records = [uptimerobot_status_page.main.dns_address]
 }
 
 ```

--- a/uptimerobot/resource_uptimerobot_monitor_test.go
+++ b/uptimerobot/resource_uptimerobot_monitor_test.go
@@ -232,7 +232,7 @@ func TestUptimeRobotDataResourceMonitor_custom_alert_contact_threshold_and_recur
 					type          = "%s"
 					url           = "%s"
 					alert_contact {
-						id         = "${uptimerobot_alert_contact.test.id}"
+						id         = uptimerobot_alert_contact.test.id
 						threshold  = 0
 						recurrence = 0
 					}
@@ -466,7 +466,7 @@ func TestUptimeRobotDataResourceMonitor_default_alert_contact(t *testing.T) {
 				data "uptimerobot_account" "account" {}
 
 				data "uptimerobot_alert_contact" "default" {
-				friendly_name = "${data.uptimerobot_account.account.email}"
+				friendly_name = data.uptimerobot_account.account.email
 				}
 
 				resource "uptimerobot_monitor" "test" {
@@ -474,7 +474,7 @@ func TestUptimeRobotDataResourceMonitor_default_alert_contact(t *testing.T) {
 					type          = "%s"
 					url           = "%s"
 					alert_contact {
-						id         = "${data.uptimerobot_alert_contact.default.id}"
+						id         = data.uptimerobot_alert_contact.default.id
 					}
 				}
 				`, FriendlyName, Type, URL),

--- a/uptimerobot/resource_uptimerobot_status_page_test.go
+++ b/uptimerobot/resource_uptimerobot_status_page_test.go
@@ -94,7 +94,7 @@ func TestUptimeRobotDataResourceStatusPage_custom_monitors(t *testing.T) {
 				}
 				resource "uptimerobot_status_page" "test" {
 					friendly_name = "%s"
-					monitors      = ["${uptimerobot_monitor.test.id}"]
+					monitors      = [uptimerobot_monitor.test.id]
 				}
 				`, friendlyName),
 				Check: resource.ComposeTestCheckFunc(

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,7 +15,7 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the UptimeRobot Provider
 provider "uptimerobot" {
-  api_key = "${var.uptimerobot_api_key}"
+  api_key = var.uptimerobot_api_key
 }
 
 # Create a monitor

--- a/website/docs/r/status_page.html.markdown
+++ b/website/docs/r/status_page.html.markdown
@@ -18,7 +18,7 @@ resource "uptimerobot_status_page" "my_status_page" {
   custom_domain  = "status.example.com"
   password       = "WeAreAwsome"
   sort_monitors  = "down-up-paused"
-  monitors       = ["${resource.uptimerobot_monitor.main.id}"]
+  monitors       = [uptimerobot_monitor.main.id]
 }
 ```
 


### PR DESCRIPTION
Currently, if examples are copied from README.md, Terraform prints
following warnings:

```
Warning: Interpolation-only expressions are deprecated

  on uptimerobot.tf line 21, in resource "uptimerobot_monitor" "main":
    21:     id = "${uptimerobot_alert_contact.slack.id}"
```

This commit fixes that by removing interpolation syntax from places,
where it's not needed.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>