### PR TITLE
Add support for Google Hangouts alert contact type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /.idea
 
 c.out
+
+.envrc

--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -21,6 +21,7 @@ var alertContactType = map[string]int{
 	"pushover":   9,
 	"hipchat":    10,
 	"slack":      11,
+	"hangouts":	  21,
 }
 var AlertContactType = mapKeys(alertContactType)
 


### PR DESCRIPTION
Adding support for UR's 3rd party alert contact for Google Hangouts as listed on its dashboard.

Although3rd party alert contact types are not listed in the API documentation, I've create one manually and then checked its type number via https://api.uptimerobot.com/v2/getAlertContacts