### PR TITLE
Update `alert_contact` docs to reflect unsupported SMS type

### DIFF
--- a/website/docs/r/alert_contact.html.markdown
+++ b/website/docs/r/alert_contact.html.markdown
@@ -23,7 +23,7 @@ resource `uptimerobot_alert_contact` `slack` {
 ## Arguments Reference
 
 * `friendly_name` - friendly name of the alert contact (for making it easier to distinguish from others).
-* `type` - the type of the alert contact notified (Zapier, HipChat and Slack are not supported in the api yet)
+* `type` - the type of the alert contact notified (`sms` is [not supported](https://uptimerobot.com/api/) for creation in the API yet)
 
   Possible values are the following:
   - `sms`


### PR DESCRIPTION
I tried to add an `sms` contact today and got

```
Error: Got error from UptimeRobot: {"message":"type is invalid.","parameter_name":"type","passed_value":"1","type":"invalid_parameter"}
```

Looking at the API docs, it looks like the guidance here should probably be updated?