### PR TITLE
Implement a simple workaround for Rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ resource "aws_route53_record" {
 
 ```
 
+Beware of [Uptime robot rate limiting](https://uptimerobot.com/api/). When the limit is reach,
+the provider will just wait some time before retrying, so it can be *really* slow.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):


### PR DESCRIPTION
Without this, you have errors like `Error: Got error from UptimeRobot: null` when you have too many obbjects to fetch from the API.
Yes, it will be slow, but at least it will usable :)