### PR TITLE
Handle strining of ints and json errors

### DIFF
--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -88,7 +88,7 @@ func (client UptimeRobotApiClient) GetAlertContacts() (acs []AlertContact, err e
 	}
 
 	if float64(len(acs)) != total {
-		err = errors.New("Hitting pagination limit of: " + string(page_limit))
+		err = fmt.Errorf("Hitting pagination limit of: %d", page_limit)
 	}
 
 	return

--- a/uptimerobot/api/monitor.go
+++ b/uptimerobot/api/monitor.go
@@ -2,7 +2,6 @@ package uptimerobotapi
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -96,13 +95,17 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 
 	monitors, ok := body["monitors"].([]interface{})
 	if !ok {
-		j, _ := json.Marshal(body)
-		err = errors.New("Unknown response from the server: " + string(j))
+		j, jsonErr := json.Marshal(body)
+		if err != nil {
+			err = fmt.Errorf("Unable to parse the JSON response from the server: %s. Body: %s", jsonErr, body)
+			return
+		}
+		err = fmt.Errorf("Missing 'monitors' in JSON response from the server: %v", j)
 		return
 	}
 
 	if len(monitors) < 1 {
-		err = errors.New("Monitor not found: " + string(id))
+		err = fmt.Errorf("Monitor not found: %d", id)
 		return
 	}
 


### PR DESCRIPTION
It isn't super safe to string() an int, slightly better to use
fmt.errorf.

Also added handling for json decode errors