### PR TITLE
feat: add new alert contact types

### DIFF
--- a/uptimerobot/api/alert_contact.go
+++ b/uptimerobot/api/alert_contact.go
@@ -11,18 +11,22 @@ import (
 const page_limit = 10
 
 var alertContactType = map[string]int{
-	"sms":        1,
-	"email":      2,
-	"twitter-dm": 3,
-	"boxcar":     4,
-	"webhook":    5,
-	"pushbullet": 6,
-	"zapier":     7,
-	"pushover":   9,
-	"hipchat":    10,
-	"slack":      11,
-	"telegram":		18,
-	"hangouts":	  21,
+	"sms":         1,
+	"email":       2,
+	"twitter-dm":  3,
+	"boxcar":      4,
+	"webhook":     5,
+	"pushbullet":  6,
+	"zapier":      7,
+	"pushover":    9,
+	"hipchat":     10,
+	"slack":       11,
+	"pagerduty":   16,
+	"opsgenie":    17,
+	"telegram":    18,
+	"ms-teams":    20,
+	"google-chat": 21,
+	"discord":     23,
 }
 var AlertContactType = mapKeys(alertContactType)
 

--- a/website/docs/r/alert_contact.html.markdown
+++ b/website/docs/r/alert_contact.html.markdown
@@ -34,10 +34,14 @@ resource `uptimerobot_alert_contact` `slack` {
   - `pushbullet`
   - `zapier`
   - `pushover`
+  - `pagerduty`
+  - `opsgenie`
   - `hipchat`
   - `slack`
   - `telegram`
-  - `hangouts`
+  - `google-chat`
+  - `ms-teams`
+  - `discord`
 * `value` - alert contact's address/phone/url
 
 ## Attributes Reference


### PR DESCRIPTION
Adds all the supported alert contact types supported by uptimerobot as it is described in the API docs(https://uptimerobot.com/api/).
Fixes #107